### PR TITLE
Refactor Payment flow

### DIFF
--- a/src/main/java/com/tech_challenge_fiap/adapter/service/inbound/controller/PaymentController.java
+++ b/src/main/java/com/tech_challenge_fiap/adapter/service/inbound/controller/PaymentController.java
@@ -2,14 +2,14 @@ package com.tech_challenge_fiap.adapter.service.inbound.controller;
 
 import com.tech_challenge_fiap.adapter.service.inbound.dto.PaymentRequestDto;
 import com.tech_challenge_fiap.core.domain.payment.PaymentUseCase;
-import com.tech_challenge_fiap.util.exception.OrderNotFoundException;
 import lombok.AllArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import static com.tech_challenge_fiap.util.converter.OrderConverter.toResponse;
 
 @RestController
 @RequestMapping("/v1/payments")
@@ -20,13 +20,7 @@ public class PaymentController {
 
     @PatchMapping
     public ResponseEntity<?> create(@RequestBody PaymentRequestDto paymentRequestDto) {
-        try {
-            var updatedOrder = paymentUseCase.updatePaymentStatus(paymentRequestDto);
-            return ResponseEntity.ok(updatedOrder);
-        } catch (OrderNotFoundException e) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
-        } catch (Exception e) {
-            return ResponseEntity.internalServerError().body(e.getMessage());
-        }
+        var updatedOrder = paymentUseCase.updatePaymentStatus(paymentRequestDto);
+        return ResponseEntity.ok(toResponse(updatedOrder));
     }
 }

--- a/src/main/java/com/tech_challenge_fiap/adapter/service/inbound/dto/PaymentRequestDto.java
+++ b/src/main/java/com/tech_challenge_fiap/adapter/service/inbound/dto/PaymentRequestDto.java
@@ -16,5 +16,5 @@ public class PaymentRequestDto {
     private String orderId;
 
     @NonNull
-    private PaymentStatusDto status;
+    private String status;
 }

--- a/src/main/java/com/tech_challenge_fiap/adapter/service/inbound/dto/PaymentStatusDto.java
+++ b/src/main/java/com/tech_challenge_fiap/adapter/service/inbound/dto/PaymentStatusDto.java
@@ -1,7 +1,0 @@
-package com.tech_challenge_fiap.adapter.service.inbound.dto;
-
-public enum PaymentStatusDto {
-    WAITING_PAYMENT,
-    PAID,
-    CANCELED;
-}

--- a/src/main/java/com/tech_challenge_fiap/adapter/service/inbound/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/tech_challenge_fiap/adapter/service/inbound/handler/GlobalExceptionHandler.java
@@ -93,4 +93,10 @@ public class GlobalExceptionHandler {
     public ResponseEntity<String> handleOrderProductsCantBeNullOrEmpty(CouldNotCreatePaymentException ex) {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ex.getMessage());
     }
+    
+    @ExceptionHandler(NotSupportedPaymentStatusException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<String> handleNotSupportedPaymentStatus(NotSupportedPaymentStatusException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+    }
 }

--- a/src/main/java/com/tech_challenge_fiap/application/service/order/OrderUseCaseImpl.java
+++ b/src/main/java/com/tech_challenge_fiap/application/service/order/OrderUseCaseImpl.java
@@ -58,7 +58,7 @@ public class OrderUseCaseImpl implements OrderUseCase {
     public Order updatePaymentStatus(PaymentRequestDto paymentRequestDto) {
         var order = orderRepository.getOrderById(paymentRequestDto.getOrderId());
 
-        PaymentStatusEnum paymentStatusEnum = PaymentStatusEnum.valueOf(paymentRequestDto.getStatus().name());
+        PaymentStatusEnum paymentStatusEnum = PaymentStatusEnum.safeValueOf(paymentRequestDto.getStatus());
         order.getPayment().setStatus(paymentStatusEnum);
 
         return orderRepository.save(orderToEntity(order));

--- a/src/main/java/com/tech_challenge_fiap/core/domain/payment/PaymentStatusEnum.java
+++ b/src/main/java/com/tech_challenge_fiap/core/domain/payment/PaymentStatusEnum.java
@@ -1,7 +1,17 @@
 package com.tech_challenge_fiap.core.domain.payment;
 
+import com.tech_challenge_fiap.util.exception.NotSupportedPaymentStatusException;
+
 public enum PaymentStatusEnum {
     WAITING_PAYMENT,
     PAID,
     CANCELED;
+
+    public static PaymentStatusEnum safeValueOf(String status) {
+        try {
+            return PaymentStatusEnum.valueOf(status);
+        } catch(Exception e) {
+            throw new NotSupportedPaymentStatusException(status);
+        }
+    }
 }

--- a/src/main/java/com/tech_challenge_fiap/util/exception/NotSupportedPaymentStatusException.java
+++ b/src/main/java/com/tech_challenge_fiap/util/exception/NotSupportedPaymentStatusException.java
@@ -1,0 +1,7 @@
+package com.tech_challenge_fiap.util.exception;
+
+public class NotSupportedPaymentStatusException extends RuntimeException {
+    public NotSupportedPaymentStatusException(String paymentStatus) {
+        super(String.format("Payment Status '%s' is not supported", paymentStatus));
+    }
+}


### PR DESCRIPTION
This MR do some refactors on payment flow 

1 - Return a response order instead of the Domain.
2 - Change the PaymentStatusDTO to string and create a NotSupportedPaymentStatusException to be returned if the payment method is not valid.
3 - Use GlobalExceptionHandler.